### PR TITLE
Preparation for release 0.0.2.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -3,4 +3,4 @@ with several additions made by Tim McGilchrist.
 
 The initial code and subsequent changes are licensed under a 3-point BSD style license.
 
-See LICENCE or https://github.com/tmcgilchrist/twine/blob/master/LICENCE.
+See LICENCE or https://github.com/tmcgilchrist/entwine/blob/master/LICENCE.

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+* 0.0.2
+ - Update async to 2.2. This version of async changed the exceptions thrown, see
+   https://hackage.haskell.org/package/async-2.2/changelog for more details.
+
 * 0.0.1
  - Initial release and cleanup from ambiata/twine
  - Rename to entwine from twine, due to existing project called twine.

--- a/entwine.cabal
+++ b/entwine.cabal
@@ -1,5 +1,5 @@
 name:                  entwine
-version:               0.0.1
+version:               0.0.2
 license:               BSD3
 license-file:          LICENSE
 author:                Ambiata <info@ambiata.com>


### PR DESCRIPTION
We bumped the bounds on Async and fixed the link in the LICENCE file to the renamed repository in github.